### PR TITLE
Add fail-safe

### DIFF
--- a/server.go
+++ b/server.go
@@ -59,6 +59,14 @@ func FetchServerList(user User) List {
 	CheckError(err)
 	defer resp.Body.Close()
 
+	if len(body) == 0 {
+		resp, err = http.Get("http://c.speedtest.net/speedtest-servers-static.php")
+		CheckError(err)
+		body, err = ioutil.ReadAll(resp.Body)
+		CheckError(err)
+		defer resp.Body.Close()
+	}
+
 	// Decode xml
 	decoder := xml.NewDecoder(bytes.NewReader(body))
 	list := List{}


### PR DESCRIPTION
if `www.speedtes.net/speedtest-servers-static.php` doesn't respond the server list,
Maybe `speedtest-go` should try `c.speedtest.net/speedtest-servers-static.php` like [speedtest-cli](https://github.com/sivel/speedtest-cli/blob/7b09d8759fcbbda8a71aa49a4eaa825581b07439/speedtest_cli.py#L419)