### PR TITLE
Fix API example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ func main() {
 
 	for _, s := range targets {
 		s.PingTest()
-		s.DownloadTest()
-		s.UploadTest()
+		s.DownloadTest(false)
+		s.UploadTest(false)
 
 		fmt.Printf("Latency: %s, Download: %f, Upload: %f\n", s.Latency, s.DLSpeed, s.ULSpeed)
 	}


### PR DESCRIPTION
Looks like the functions were updated to expect `savingMode bool` and the API example wasn't updated. I've set savingMode to `false` in the example.