### PR TITLE
- bugfix for request.go

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -17,7 +17,7 @@ var client = http.Client{}
 
 // DownloadTest executes the test to measure download speed
 func (s *Server) DownloadTest(savingMode bool) error {
-	dlURL := strings.Split(s.URL, "/upload")[0]
+	dlURL := strings.Split(s.URL, "/upload.php")[0]
 	eg := errgroup.Group{}
 
 	// Warming up
@@ -196,7 +196,7 @@ func uploadRequest(ulURL string, w int) error {
 
 // PingTest executes test to measure latency
 func (s *Server) PingTest() error {
-	pingURL := strings.Split(s.URL, "/upload")[0] + "/latency.txt"
+	pingURL := strings.Split(s.URL, "/upload.php")[0] + "/latency.txt"
 
 	l := time.Duration(100000000000) // 10sec
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
@showwin  I found a bug as below:

```
Target Server: [4884]   211.28km Fuzhou (China) by China Unicom FuJian
2021/03/31 11:55:06 s.URL: http://upload1.testspeed.kaopuyun.com:8080/speedtest/upload.php
2021/03/31 11:55:06 Get http://latency.txt: dial tcp: lookup latency.txt on 192.168.1.1:53: no such host
```

![image](https://user-images.githubusercontent.com/4537336/113089486-5357cc80-921a-11eb-9d0b-2a3ccf40b9ed.png)


