### PR TITLE
Add support for the context package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _testmain.go
 .goxc.local.json
 dist/*
 speedtest-go
+
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,16 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 h1:EBTWhcAX7rNQ80RLwLCpHZBBrJuzallFHnF+yMXo928=
 github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRYS3XieqF+Z9B9gNxo/eANAJCF2eiN4=
+github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -19,7 +19,7 @@ var client = http.Client{}
 
 // DownloadTest executes the test to measure download speed
 func (s *Server) DownloadTest(savingMode bool) error {
-	return s.DownloadTestContext(context.TODO(), savingMode)
+	return s.DownloadTestContext(context.Background(), savingMode)
 }
 
 // DownloadTestContext executes the test to measure download speed, observing the given context.
@@ -85,7 +85,7 @@ func (s *Server) DownloadTestContext(ctx context.Context, savingMode bool) error
 
 // UploadTest executes the test to measure upload speed
 func (s *Server) UploadTest(savingMode bool) error {
-	return s.UploadTestContext(context.TODO(), savingMode)
+	return s.UploadTestContext(context.Background(), savingMode)
 }
 
 // UploadTestContext executes the test to measure upload speed, observing the given context.
@@ -248,7 +248,7 @@ func uploadRequest(ctx context.Context, ulURL string, w int) error {
 
 // PingTest executes test to measure latency
 func (s *Server) PingTest() error {
-	return s.PingTestContext(context.TODO())
+	return s.PingTestContext(context.Background())
 }
 
 // PingTestContext executes test to measure latency, observing the given context.

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -62,7 +62,7 @@ func (b ByDistance) Less(i, j int) bool {
 
 // FetchServerList retrieves a list of available servers
 func FetchServerList(user *User) (ServerList, error) {
-	return FetchServerListContext(context.TODO(), user)
+	return FetchServerListContext(context.Background(), user)
 }
 
 // FetchServerListContext retrieves a list of available servers, observing the given context.

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -25,7 +25,7 @@ type Users struct {
 
 // FetchUserInfo returns information about caller determined by speedtest.net
 func FetchUserInfo() (*User, error) {
-	return FetchUserInfoContext(context.TODO())
+	return FetchUserInfoContext(context.Background())
 }
 
 // FetchUserInfoContext returns information about caller determined by speedtest.net, observing the given context.

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -1,13 +1,14 @@
 package speedtest
 
 import (
-	"bytes"
+	"context"
 	"encoding/xml"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"errors"
+	"fmt"
+	"net/http"
 )
+
+const speedTestConfigUrl = "https://www.speedtest.net/speedtest-config.php"
 
 // User represents information determined about the caller by speedtest.net
 type User struct {
@@ -24,33 +25,35 @@ type Users struct {
 
 // FetchUserInfo returns information about caller determined by speedtest.net
 func FetchUserInfo() (*User, error) {
-	// Fetch xml user data
-	resp, err := http.Get("http://speedtest.net/speedtest-config.php")
+	return FetchUserInfoContext(context.TODO())
+}
+
+// FetchUserInfoContext returns information about caller determined by speedtest.net, observing the given context.
+func FetchUserInfoContext(ctx context.Context) (*User, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, speedTestConfigUrl, nil)
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+
 	defer resp.Body.Close()
 
 	// Decode xml
-	decoder := xml.NewDecoder(bytes.NewReader(body))
-	users := Users{}
-	for {
-		t, _ := decoder.Token()
-		if t == nil {
-			break
-		}
-		switch se := t.(type) {
-		case xml.StartElement:
-			decoder.DecodeElement(&users, &se)
-		}
+	decoder := xml.NewDecoder(resp.Body)
+
+	var users Users
+	if err := decoder.Decode(&users); err != nil {
+		return nil, err
 	}
-	if users.Users == nil {
+
+	if len(users.Users) == 0 {
 		return nil, errors.New("failed to fetch user information")
 	}
+
 	return &users.Users[0], nil
 }
 


### PR DESCRIPTION
Thanks for this useful library, you saved me a bunch of time recently 😄 

This PR adds support for the [`context`](https://golang.org/pkg/context/) package for any methods that do I/O.

The original methods remain, but there are new methods added to handle contexts. This is the same approach taken by the `sql` package.