### PR TITLE
[-] os.Exit is redundant

### DIFF
--- a/speedtest.go
+++ b/speedtest.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/showwin/speedtest-go/speedtest"
@@ -184,7 +183,6 @@ func showAverageServerResult(servers speedtest.Servers) {
 func checkError(err error) {
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Fatal is equivalent to Print() followed by a call to os.Exit(1).
https://pkg.go.dev/log#Fatal