### PR TITLE
Alter exposed functions that take contexts

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -24,11 +24,15 @@ var client = http.Client{}
 
 // DownloadTest executes the test to measure download speed
 func (s *Server) DownloadTest(savingMode bool) error {
-	return s.DownloadTestContext(context.Background(), savingMode, dlWarmUp, downloadRequest)
+	return s.downloadTestContext(context.Background(), savingMode, dlWarmUp, downloadRequest)
 }
 
 // DownloadTestContext executes the test to measure download speed, observing the given context.
-func (s *Server) DownloadTestContext(
+func (s *Server) DownloadTestContext(ctx context.Context, savingMode bool) error {
+	return s.downloadTestContext(ctx, savingMode, dlWarmUp, downloadRequest)
+}
+
+func (s *Server) downloadTestContext(
 	ctx context.Context,
 	savingMode bool,
 	dlWarmUp downloadWarmUpFunc,
@@ -98,11 +102,14 @@ func (s *Server) DownloadTestContext(
 
 // UploadTest executes the test to measure upload speed
 func (s *Server) UploadTest(savingMode bool) error {
-	return s.UploadTestContext(context.Background(), savingMode, ulWarmUp, uploadRequest)
+	return s.uploadTestContext(context.Background(), savingMode, ulWarmUp, uploadRequest)
 }
 
 // UploadTestContext executes the test to measure upload speed, observing the given context.
-func (s *Server) UploadTestContext(
+func (s *Server) UploadTestContext(ctx context.Context, savingMode bool) error {
+	return s.uploadTestContext(ctx, savingMode, ulWarmUp, uploadRequest)
+}
+func (s *Server) uploadTestContext(
 	ctx context.Context,
 	savingMode bool,
 	ulWarmUp uploadWarmUpFunc,

--- a/speedtest/request_test.go
+++ b/speedtest/request_test.go
@@ -14,7 +14,7 @@ func TestDownloadTestContext(t *testing.T) {
 		Latency: latency,
 	}
 
-	err := server.DownloadTestContext(
+	err := server.downloadTestContext(
 		context.Background(),
 		false,
 		mockWarmUp,
@@ -35,7 +35,7 @@ func TestDownloadTestContextSavingMode(t *testing.T) {
 		Latency: latency,
 	}
 
-	err := server.DownloadTestContext(
+	err := server.downloadTestContext(
 		context.Background(),
 		true,
 		mockWarmUp,
@@ -56,7 +56,7 @@ func TestUploadTestContext(t *testing.T) {
 		Latency: latency,
 	}
 
-	err := server.UploadTestContext(
+	err := server.uploadTestContext(
 		context.Background(),
 		false,
 		mockWarmUp,
@@ -77,7 +77,7 @@ func TestUploadTestContextSavingMode(t *testing.T) {
 		Latency: latency,
 	}
 
-	err := server.UploadTestContext(
+	err := server.uploadTestContext(
 		context.Background(),
 		true,
 		mockWarmUp,


### PR DESCRIPTION
See https://github.com/showwin/speedtest-go/pull/41#issuecomment-893234635 for detail - the previous alterations made in https://github.com/showwin/speedtest-go/pull/44 made it impossible to call the context-observing versions of the `DownloadTest` and `UploadTest` functions in the same was as the context-free versions.