### PR TITLE
Add speedtest struct which contains the global variables used

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -271,7 +271,7 @@ func (s *Server) PingTestContext(ctx context.Context) error {
 			return err
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := s.doer.Do(req)
 		if err != nil {
 			return err
 		}

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -262,7 +262,7 @@ func (s *Server) PingTest() error {
 func (s *Server) PingTestContext(ctx context.Context) error {
 	pingURL := strings.Split(s.URL, "/upload.php")[0] + "/latency.txt"
 
-	l := time.Duration(100000000000) // 10sec
+	l := time.Second * 10
 	for i := 0; i < 3; i++ {
 		sTime := time.Now()
 

--- a/speedtest/request_test.go
+++ b/speedtest/request_test.go
@@ -3,6 +3,7 @@ package speedtest
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -91,12 +92,12 @@ func TestUploadTestContextSavingMode(t *testing.T) {
 	}
 }
 
-func mockWarmUp(ctx context.Context, dlURL string) error {
+func mockWarmUp(ctx context.Context, doer *http.Client, dlURL string) error {
 	time.Sleep(100 * time.Millisecond)
 	return nil
 }
 
-func mockRequest(ctx context.Context, dlURL string, w int) error {
+func mockRequest(ctx context.Context, doer *http.Client, dlURL string, w int) error {
 	fmt.Sprintln(w)
 	time.Sleep(500 * time.Millisecond)
 	return nil

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -64,7 +64,7 @@ func (b ByDistance) Less(i, j int) bool {
 
 // FetchServerList retrieves a list of available servers
 func (client *Speedtest) FetchServerList(user *User) (ServerList, error) {
-	return FetchServerListContext(context.Background(), user)
+	return client.FetchServerListContext(context.Background(), user)
 }
 
 // FetchServerList retrieves a list of available servers

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -30,6 +30,8 @@ type Server struct {
 	Latency  time.Duration `json:"latency"`
 	DLSpeed  float64       `json:"dl_speed"`
 	ULSpeed  float64       `json:"ul_speed"`
+
+	doer *http.Client
 }
 
 // ServerList list of Server
@@ -61,18 +63,23 @@ func (b ByDistance) Less(i, j int) bool {
 }
 
 // FetchServerList retrieves a list of available servers
-func FetchServerList(user *User) (ServerList, error) {
+func (client *Speedtest) FetchServerList(user *User) (ServerList, error) {
 	return FetchServerListContext(context.Background(), user)
 }
 
+// FetchServerList retrieves a list of available servers
+func FetchServerList(user *User) (ServerList, error) {
+	return defaultClient.FetchServerList(user)
+}
+
 // FetchServerListContext retrieves a list of available servers, observing the given context.
-func FetchServerListContext(ctx context.Context, user *User) (ServerList, error) {
+func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User) (ServerList, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, speedTestServersUrl, nil)
 	if err != nil {
 		return ServerList{}, err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.doer.Do(req)
 	if err != nil {
 		return ServerList{}, err
 	}
@@ -85,7 +92,7 @@ func FetchServerListContext(ctx context.Context, user *User) (ServerList, error)
 			return ServerList{}, err
 		}
 
-		resp, err = http.DefaultClient.Do(req)
+		resp, err = client.doer.Do(req)
 		if err != nil {
 			return ServerList{}, err
 		}
@@ -99,6 +106,11 @@ func FetchServerListContext(ctx context.Context, user *User) (ServerList, error)
 	var list ServerList
 	if err := decoder.Decode(&list); err != nil {
 		return list, err
+	}
+
+	// set doer of server
+	for _, s := range list.Servers {
+		s.doer = client.doer
 	}
 
 	// Calculate distance
@@ -119,6 +131,11 @@ func FetchServerListContext(ctx context.Context, user *User) (ServerList, error)
 	}
 
 	return list, nil
+}
+
+// FetchServerListContext retrieves a list of available servers, observing the given context.
+func FetchServerListContext(ctx context.Context, user *User) (ServerList, error) {
+	return defaultClient.FetchServerListContext(ctx, user)
 }
 
 func distance(lat1 float64, lon1 float64, lat2 float64, lon2 float64) float64 {

--- a/speedtest/server_test.go
+++ b/speedtest/server_test.go
@@ -9,7 +9,10 @@ func TestFetchServerList(t *testing.T) {
 		Lon: "138.44",
 		Isp: "Hello",
 	}
-	serverList, err := FetchServerList(&user)
+
+	client := New()
+
+	serverList, err := client.FetchServerList(&user)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -1,0 +1,33 @@
+package speedtest
+
+import "net/http"
+
+// Speedtest is a speedtest client.
+type Speedtest struct {
+	doer *http.Client
+}
+
+// Option is a function that can be passed to New to modify the Client.
+type Option func(*Speedtest)
+
+// WithDoer sets the http.Client used to make requests.
+func WithDoer(doer *http.Client) Option {
+	return func(s *Speedtest) {
+		s.doer = doer
+	}
+}
+
+// New creates a new speedtest client.
+func New(opts ...Option) *Speedtest {
+	s := &Speedtest{
+		doer: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+var defaultClient = New()

--- a/speedtest/speedtest_test.go
+++ b/speedtest/speedtest_test.go
@@ -1,0 +1,26 @@
+package speedtest
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("DefaultDoer", func(t *testing.T) {
+		c := New()
+
+		if c.doer == nil {
+			t.Error("doer is nil by")
+		}
+	})
+
+	t.Run("CustomDoer", func(t *testing.T) {
+		doer := &http.Client{}
+
+		c := New(WithDoer(doer))
+		if c.doer != doer {
+			t.Error("doer is not the same")
+		}
+	})
+
+}

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -24,18 +24,23 @@ type Users struct {
 }
 
 // FetchUserInfo returns information about caller determined by speedtest.net
-func FetchUserInfo() (*User, error) {
+func (client *Speedtest) FetchUserInfo() (*User, error) {
 	return FetchUserInfoContext(context.Background())
 }
 
+// FetchUserInfo returns information about caller determined by speedtest.net
+func FetchUserInfo() (*User, error) {
+	return defaultClient.FetchUserInfo()
+}
+
 // FetchUserInfoContext returns information about caller determined by speedtest.net, observing the given context.
-func FetchUserInfoContext(ctx context.Context) (*User, error) {
+func (client *Speedtest) FetchUserInfoContext(ctx context.Context) (*User, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, speedTestConfigUrl, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.doer.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -55,6 +60,11 @@ func FetchUserInfoContext(ctx context.Context) (*User, error) {
 	}
 
 	return &users.Users[0], nil
+}
+
+// FetchUserInfoContext returns information about caller determined by speedtest.net, observing the given context.
+func FetchUserInfoContext(ctx context.Context) (*User, error) {
+	return defaultClient.FetchUserInfoContext(ctx)
 }
 
 // String representation of User

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -25,7 +25,7 @@ type Users struct {
 
 // FetchUserInfo returns information about caller determined by speedtest.net
 func (client *Speedtest) FetchUserInfo() (*User, error) {
-	return FetchUserInfoContext(context.Background())
+	return client.FetchUserInfoContext(context.Background())
 }
 
 // FetchUserInfo returns information about caller determined by speedtest.net

--- a/speedtest/user_test.go
+++ b/speedtest/user_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestFetchUserInfo(t *testing.T) {
-	user, err := FetchUserInfo()
+	client := New()
+
+	user, err := client.FetchUserInfo()
 	if err != nil {
 		t.Errorf(err.Error())
 	}


### PR DESCRIPTION
Thanks for useful package! 🤝 
We need to bench multiple proxies concurrently. It's not possible in current implementation without dirty hacks. 
So, instead of use global `http.DefaultClient` we add struct `speedtest.Speedtest` which contains it in itself and allows you to redefine. Backward compatibility is maintained, we use method like in `math/rand` package. 