### PR TITLE
fix: speed value can be negative if the bandwidth is large

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -51,8 +51,17 @@ func (s *Server) downloadTestContext(
 		return err
 	}
 	fTime := time.Now()
+
+	// If the bandwidth is too large, the download sometimes finish earlier than the latency.
+	// In this case, we ignore the the latency that is included server information.
+	// This is not affected to the final result since this is a warm up test.
+	timeToSpend := fTime.Sub(sTime.Add(s.Latency)).Seconds()
+	if timeToSpend < 0 {
+		timeToSpend = fTime.Sub(sTime).Seconds()
+	}
+
 	// 1.125MB for each request (750 * 750 * 2)
-	wuSpeed := 1.125 * 8 * 2 / fTime.Sub(sTime.Add(s.Latency)).Seconds()
+	wuSpeed := 1.125 * 8 * 2 / timeToSpend
 
 	// Decide workload by warm up speed
 	workload := 0


### PR DESCRIPTION
This change will fix https://github.com/showwin/speedtest-go/issues/57.

This problem can be occurred when download warm-up process finished too fast.
`s.Latency` value is calculated when we get a server information, it means this value is not related to the warm-up process.
so `sTime.Add(s.Latency)` can be larger than `fTime` [here](https://github.com/showwin/speedtest-go/compare/fix_minus_speed?expand=1#diff-0ce50d5f1d88fb9df796031f74be6eb59c03f1469f49c84e4b5838ebcd6a01dbR58) if the latency is faster during warm-up than during getting the server information and download process finished too fast.
Then if `wuSpeed` is negative value, speedtest-go skip the main process to measure download speed [here](https://github.com/showwin/speedtest-go/blob/fix_minus_speed/speedtest/request.go#L85-L87), so the final result can be negative value.