### PR TITLE
Add --world option and support test somewhere with predefined location

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ import (
 
 func main() {
 	user, _ := speedtest.FetchUserInfo()
-    // user.SetLocationByCity("Tokyo")
+	// Get a list of servers near a specified location
+	// user.SetLocationByCity("Tokyo")
+	// user.SetLocation("Osaka", 34.6952, 135.5006)
 	
 	serverList, _ := speedtest.FetchServerList(user)
 	targets, _ := serverList.FindServer([]int{})

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ import (
 
 func main() {
 	user, _ := speedtest.FetchUserInfo()
-
+    // user.SetLocationByCity("Tokyo")
+	
 	serverList, _ := speedtest.FetchServerList(user)
 	targets, _ := serverList.FindServer([]int{})
 

--- a/speedtest.go
+++ b/speedtest.go
@@ -15,6 +15,7 @@ var (
 	serverIds  = kingpin.Flag("server", "Select server id to speedtest.").Short('s').Ints()
 	savingMode = kingpin.Flag("saving-mode", "Using less memory (≒10MB), though low accuracy (especially > 30Mbps).").Bool()
 	jsonOutput = kingpin.Flag("json", "Output results in json format").Bool()
+	world      = kingpin.Flag("world", "Change the current user location").String()
 )
 
 type fullOutput struct {
@@ -32,6 +33,14 @@ func main() {
 	if err != nil {
 		fmt.Println("Warning: Cannot fetch user information. http://www.speedtest.net/speedtest-config.php is temporarily unavailable.")
 	}
+
+	if len(*world) > 0 {
+		err = user.Location(*world)
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+	}
+
 	if !*jsonOutput {
 		showUser(user)
 	}

--- a/speedtest.go
+++ b/speedtest.go
@@ -32,6 +32,7 @@ func main() {
 	user, err := speedtest.FetchUserInfo()
 	if err != nil {
 		fmt.Println("Warning: Cannot fetch user information. http://www.speedtest.net/speedtest-config.php is temporarily unavailable.")
+		return
 	}
 
 	if len(*world) > 0 {

--- a/speedtest.go
+++ b/speedtest.go
@@ -45,16 +45,14 @@ func main() {
 	if len(*city) > 0 {
 		err = user.SetLocationByCity(*city)
 		if err != nil {
-			fmt.Println(err.Error())
-			fmt.Printf("Warning: skipping...command line arguments: --city=%v\n", *city)
+			fmt.Printf("Warning: skipping command line arguments: --city. err: %v\n", err.Error())
 		}
 	}
 
 	if len(*location) > 0 {
 		err = user.ParseAndSetLocation(*location)
 		if err != nil {
-			fmt.Println(err.Error())
-			fmt.Printf("Warning: skipping...command line arguments: --location=%v\n", *location)
+			fmt.Printf("Warning: skipping command line arguments: --location. err: %v\n", err.Error())
 		}
 	}
 

--- a/speedtest.go
+++ b/speedtest.go
@@ -39,6 +39,7 @@ func main() {
 		err = user.Location(*world)
 		if err != nil {
 			fmt.Println(err.Error())
+			fmt.Printf("Warning: skipping...command line arguments: --world=%v\n", *world)
 		}
 	}
 

--- a/speedtest.go
+++ b/speedtest.go
@@ -11,11 +11,13 @@ import (
 )
 
 var (
-	showList   = kingpin.Flag("list", "Show available speedtest.net servers.").Short('l').Bool()
-	serverIds  = kingpin.Flag("server", "Select server id to speedtest.").Short('s').Ints()
-	savingMode = kingpin.Flag("saving-mode", "Using less memory (≒10MB), though low accuracy (especially > 30Mbps).").Bool()
-	jsonOutput = kingpin.Flag("json", "Output results in json format").Bool()
-	world      = kingpin.Flag("world", "Change the current user location").String()
+	showList     = kingpin.Flag("list", "Show available speedtest.net servers.").Short('l').Bool()
+	serverIds    = kingpin.Flag("server", "Select server id to speedtest.").Short('s').Ints()
+	savingMode   = kingpin.Flag("saving-mode", "Using less memory (≒10MB), though low accuracy (especially > 30Mbps).").Bool()
+	jsonOutput   = kingpin.Flag("json", "Output results in json format").Bool()
+	location     = kingpin.Flag("location", "Change the location with a precise coordinate.").String()
+	city         = kingpin.Flag("city", "Change the location with a predefined city label.").String()
+	showCityList = kingpin.Flag("city-list", "List all predefined city label.").Bool()
 )
 
 type fullOutput struct {
@@ -35,11 +37,24 @@ func main() {
 		return
 	}
 
-	if len(*world) > 0 {
-		err = user.Location(*world)
+	if *showCityList {
+		speedtest.PrintCityList()
+		return
+	}
+
+	if len(*city) > 0 {
+		err = user.SetLocationByCity(*city)
 		if err != nil {
 			fmt.Println(err.Error())
-			fmt.Printf("Warning: skipping...command line arguments: --world=%v\n", *world)
+			fmt.Printf("Warning: skipping...command line arguments: --city=%v\n", *city)
+		}
+	}
+
+	if len(*location) > 0 {
+		err = user.ParseAndSetLocation(*location)
+		if err != nil {
+			fmt.Println(err.Error())
+			fmt.Printf("Warning: skipping...command line arguments: --location=%v\n", *location)
 		}
 	}
 

--- a/speedtest/location.go
+++ b/speedtest/location.go
@@ -1,0 +1,17 @@
+package speedtest
+
+type Location struct {
+	Lat float64
+	Lon float64
+}
+
+// Locations TODO more location need to added
+var Locations = map[string]Location{
+	"hongkong":     {Lat: 22.3207, Lon: 114.1689},
+	"chiyoda":      {Lat: 35.6869, Lon: 139.7575},
+	"london":       {Lat: 51.5063, Lon: -0.1201},
+	"moscow":       {Lat: 55.7520, Lon: 37.6175},
+	"beijing":      {Lat: 39.5600, Lon: 116.2000},
+	"paris":        {Lat: 48.8600, Lon: 2.3390},
+	"sanfrancisco": {Lat: 37.7687, Lon: -122.4754},
+}

--- a/speedtest/location.go
+++ b/speedtest/location.go
@@ -1,5 +1,7 @@
 package speedtest
 
+import "fmt"
+
 type Location struct {
 	Lat float64
 	Lon float64
@@ -7,11 +9,22 @@ type Location struct {
 
 // Locations TODO more location need to added
 var Locations = map[string]Location{
-	"hongkong":     {Lat: 22.3207, Lon: 114.1689},
-	"chiyoda":      {Lat: 35.6869, Lon: 139.7575},
-	"london":       {Lat: 51.5063, Lon: -0.1201},
-	"moscow":       {Lat: 55.7520, Lon: 37.6175},
-	"beijing":      {Lat: 39.5600, Lon: 116.2000},
-	"paris":        {Lat: 48.8600, Lon: 2.3390},
-	"sanfrancisco": {Lat: 37.7687, Lon: -122.4754},
+	"br-brasilia":     {-15.793876, -47.8835327},
+	"cn-hongkong":     {22.3207, 114.1689},
+	"jp-tokyo":        {35.6869, 139.7575},
+	"uk-london":       {51.5063, -0.1201},
+	"ru-moscow":       {55.7520, 37.6175},
+	"cn-beijing":      {39.8721243, 116.4077473},
+	"fr-paris":        {48.8600, 2.3390},
+	"us-sanfrancisco": {37.7687, -122.4754},
+	"us-newyork":      {40.7200876, -74.0220945},
+	"sg-yishun":       {1.4230218, 103.8404728},
+	"in-delhi":        {28.6251287, 77.1960896},
+}
+
+func PrintCityList() {
+	fmt.Println("Available city labels (case insensitive): ")
+	for k, v := range Locations {
+		fmt.Printf("%s -> %v\n", k, v)
+	}
 }

--- a/speedtest/location.go
+++ b/speedtest/location.go
@@ -3,28 +3,45 @@ package speedtest
 import "fmt"
 
 type Location struct {
+	CC  string
 	Lat float64
 	Lon float64
 }
 
 // Locations TODO more location need to added
 var Locations = map[string]Location{
-	"br-brasilia":     {-15.793876, -47.8835327},
-	"cn-hongkong":     {22.3207, 114.1689},
-	"jp-tokyo":        {35.6869, 139.7575},
-	"uk-london":       {51.5063, -0.1201},
-	"ru-moscow":       {55.7520, 37.6175},
-	"cn-beijing":      {39.8721243, 116.4077473},
-	"fr-paris":        {48.8600, 2.3390},
-	"us-sanfrancisco": {37.7687, -122.4754},
-	"us-newyork":      {40.7200876, -74.0220945},
-	"sg-yishun":       {1.4230218, 103.8404728},
-	"in-delhi":        {28.6251287, 77.1960896},
+	"brasilia":     {"br", -15.793876, -47.8835327},
+	"hongkong":     {"hk", 22.3106806, 114.1700546},
+	"tokyo":        {"jp", 35.680938, 139.7674114},
+	"london":       {"uk", 51.5072493, -0.1288861},
+	"moscow":       {"ru", 55.7497248, 37.615989},
+	"beijing":      {"cn", 39.8721243, 116.4077473},
+	"paris":        {"fr", 48.8626026, 2.3477229},
+	"sanfrancisco": {"us", 37.7540028, -122.4429967},
+	"newyork":      {"us", 40.7200876, -74.0220945},
+	"yishun":       {"sg", 1.4230218, 103.8404728},
+	"delhi":        {"in", 28.6251287, 77.1960896},
+	"monterrey":    {"mx", 25.6881435, -100.3073485},
+	"berlin":       {"de", 52.5168128, 13.4009469},
+	"maputo":       {"mz", -25.9579267, 32.5760444},
+	"honolulu":     {"us", 20.8247065, -156.918706},
+	"seoul":        {"kr", 37.6086268, 126.7179721},
+	"osaka":        {"jp", 34.6952743, 135.5006967},
+	"shanghai":     {"cn", 31.2292105, 121.4661666},
+	"urumqi":       {"cn", 43.8256624, 87.6058564},
+	"ottawa":       {"ca", 45.4161836, -75.7035467},
+	"capetown":     {"za", -33.9391993, 18.4316716},
+	"sydney":       {"au", -33.8966622, 151.1731861},
+	"perth":        {"au", -31.9551812, 115.8591904},
+	"warsaw":       {"pl", 52.2396659, 21.0129345},
+	"kampala":      {"ug", 0.3070027, 32.5675581},
+	"bangkok":      {"th", 13.7248936, 100.493026},
 }
 
 func PrintCityList() {
 	fmt.Println("Available city labels (case insensitive): ")
+	fmt.Println(" CC\t\tCityLabel\tLocation")
 	for k, v := range Locations {
-		fmt.Printf("%s -> %v\n", k, v)
+		fmt.Printf("(%v)\t%20s\t[%v, %v]\n", v.CC, k, v.Lat, v.Lon)
 	}
 }

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const speedTestServersUrl = "https://www.speedtest.net/api/js/servers?engine=js&limit=10"
+const speedTestServersUrl = "https://www.speedtest.net/api/js/servers?limit=10"
 const speedTestServersAlternativeUrl = "https://www.speedtest.net/speedtest-servers-static.php"
 
 type PayloadType int
@@ -82,7 +82,8 @@ func FetchServers(user *User) (Servers, error) {
 
 // FetchServerListContext retrieves a list of available servers, observing the given context.
 func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User) (Servers, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, speedTestServersUrl, nil)
+	fetchUrl := fmt.Sprintf("%s&lat=%s&lon=%s", speedTestServersUrl, user.VLat, user.VLon)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchUrl, nil)
 	if err != nil {
 		return Servers{}, err
 	}

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -87,15 +87,15 @@ func (u *User) SetLocationByCity(locationLabel string) (err error) {
 	if ok {
 		u.SetLocation(locationLabel, loc.Lat, loc.Lon)
 	} else {
-		err = errors.New("Warning: no found predefined label: " + locationLabel)
+		err = fmt.Errorf("no found predefined label: %s", locationLabel)
 	}
 	return
 }
 
 // SetLocation set the latitude and longitude of the current user
 func (u *User) SetLocation(locationName string, latitude float64, longitude float64) {
-	u.VLat = fmt.Sprintf("%.4f", latitude)
-	u.VLon = fmt.Sprintf("%.4f", longitude)
+	u.VLat = fmt.Sprintf("%v", latitude)
+	u.VLon = fmt.Sprintf("%v", longitude)
 	u.VLoc = strings.Title(locationName)
 }
 
@@ -116,17 +116,17 @@ func (u *User) ParseAndSetLocation(coordinateStr string) error {
 		u.SetLocation("Customize", lat, lon)
 		return nil
 	}
-	return errors.New("Warning: invalid location input: " + coordinateStr)
+	return fmt.Errorf("invalid location input: %s", coordinateStr)
 }
 
 // betweenRange latitude and longitude range check
 func betweenRange(inputStrValue string, interval float64) (float64, error) {
 	value, err := strconv.ParseFloat(inputStrValue, 64)
 	if err != nil {
-		return 0, errors.New(fmt.Sprintf("Warning: invalid input: %v", inputStrValue))
+		return 0, fmt.Errorf("invalid input: %v", inputStrValue)
 	}
 	if value < -interval || interval < value {
-		return 0, errors.New(fmt.Sprintf("Warning: invalid input. got: %v, expected between -%v and %v", inputStrValue, interval, interval))
+		return 0, fmt.Errorf("invalid input. got: %v, expected between -%v and %v", inputStrValue, interval, interval)
 	}
 	return value, nil
 }

--- a/speedtest/user_test.go
+++ b/speedtest/user_test.go
@@ -36,7 +36,7 @@ func TestFetchUserInfo(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if lon < -180 || 180 < lon {
-		t.Errorf("Invalid Latitude. got: %v, expected between -90 and 90", user.Lon)
+		t.Errorf("Invalid Longitude. got: %v, expected between -180 and 180", user.Lon)
 	}
 
 	// Isp


### PR DESCRIPTION
When using the new api, we can easily change the current location to get a different server list.
implement  #2 Use map to pre-mark each location

usage:
Select the best server under the current label for testing
 ~~`.\speedtest-go.exe --world=beijing`~~
`.\speedtest-go.exe --city=tokyo`

List servers under the current label
~~`.\speedtest-go.exe --world=paris -l`~~
`.\speedtest-go.exe --city=tokyo -l`