### PR TITLE
Add User-Agent to http request to avoid request error in some cases.

### DIFF
--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -88,6 +88,8 @@ func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User)
 		return Servers{}, err
 	}
 
+	req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
+
 	resp, err := client.doer.Do(req)
 	if err != nil {
 		return Servers{}, err
@@ -102,6 +104,8 @@ func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User)
 		if err != nil {
 			return Servers{}, err
 		}
+
+		req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
 
 		resp, err = client.doer.Do(req)
 		if err != nil {

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -45,6 +45,8 @@ func (client *Speedtest) FetchUserInfoContext(ctx context.Context) (*User, error
 		return nil, err
 	}
 
+	req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
+
 	resp, err := client.doer.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi,
I do not know Go and never work with it.
It is probably not the best way to fix the problem. 
Having a central way that always set User-Agent will be probably better.
Nevertheless, with this change, tests are greens otherwise that are failing.

```
go test -v
=== RUN   TestDownloadTestContext
--- PASS: TestDownloadTestContext (0.61s)
=== RUN   TestDownloadTestContextSavingMode
--- PASS: TestDownloadTestContextSavingMode (0.61s)
=== RUN   TestUploadTestContext
--- PASS: TestUploadTestContext (0.62s)
=== RUN   TestUploadTestContextSavingMode
--- PASS: TestUploadTestContextSavingMode (0.61s)
=== RUN   TestFetchServerList
--- PASS: TestFetchServerList (0.32s)
=== RUN   TestDistance
--- PASS: TestDistance (0.00s)
=== RUN   TestFindServer
--- PASS: TestFindServer (0.00s)
=== RUN   TestNew
=== RUN   TestNew/DefaultDoer
=== RUN   TestNew/CustomDoer
--- PASS: TestNew (0.00s)
    --- PASS: TestNew/DefaultDoer (0.00s)
    --- PASS: TestNew/CustomDoer (0.00s)
=== RUN   TestFetchUserInfo
--- PASS: TestFetchUserInfo (0.03s)
PASS
ok      github.com/showwin/speedtest-go/speedtest       2.994s
```