### PR TITLE
disable arm64 build temporally

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
       - 386
       - amd64
       - arm
-      - arm64
+      # - arm64 ref: https://github.com/showwin/speedtest-go/actions/runs/3426179465/jobs/5771140354
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
Due to https://github.com/showwin/speedtest-go/actions/runs/3426179465/jobs/5771140354 error