### PR TITLE
[fix] Ignore windows/arm64 pair to re-enable linux/arm64 releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,10 @@ builds:
       - 386
       - amd64
       - arm
-      # - arm64 ref: https://github.com/showwin/speedtest-go/actions/runs/3426179465/jobs/5771140354
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
This commit resolves the the issue raised in #81, by specifically ignoring the `windows/arm64` pair, so that `linux/arm64` can continue built. It looks like https://github.com/goreleaser/goreleaser/issues/142 raised this already with the `goreleaser` folks, there was a prior PR to skip unsupported `goos`/`goarch` pairs, but it never got merged 😞. To get an arm64 release, you'll probably need to create a new release.

**Testing**
To test this, I tagged and ran goreleaser locally. Not this PR doesn't actually include the `1.2,2` release tag, I just created that locally for this test.
```bash
~/speedtest-go ❯❯❯ git tag 1.2.2                                                                                                     ✘ 1
~/speedtest-go ❯❯❯ goreleaser build
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=5cbab8a3c2f92f810a05259b95df890e9d536a9c latest tag=1.2.2
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
    • running                                        hook=go generate ./...
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/speedtest-go_windows_amd64_v1/speedtest-go.exe
    • building                                       binary=dist/speedtest-go_linux_amd64_v1/speedtest-go
    • building                                       binary=dist/speedtest-go_linux_386/speedtest-go
    • building                                       binary=dist/speedtest-go_linux_arm64/speedtest-go
    • building                                       binary=dist/speedtest-go_linux_arm_6/speedtest-go
    • building                                       binary=dist/speedtest-go_windows_386/speedtest-go.exe
    • building                                       binary=dist/speedtest-go_windows_arm_6/speedtest-go.exe
    • building                                       binary=dist/speedtest-go_darwin_amd64_v1/speedtest-go
    • building                                       binary=dist/speedtest-go_darwin_arm64/speedtest-go
    • took: 39s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 39s
  ```