### PR TITLE
set custom user-agent on all requests

### DIFF
--- a/speedtest.go
+++ b/speedtest.go
@@ -28,7 +28,7 @@ type fullOutput struct {
 type outputTime time.Time
 
 func main() {
-	kingpin.Version("1.2.1")
+	kingpin.Version(speedtest.Version())
 	kingpin.Parse()
 
 	user, err := speedtest.FetchUserInfo()

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -88,8 +88,6 @@ func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User)
 		return Servers{}, err
 	}
 
-	req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
-
 	resp, err := client.doer.Do(req)
 	if err != nil {
 		return Servers{}, err
@@ -104,8 +102,6 @@ func (client *Speedtest) FetchServerListContext(ctx context.Context, user *User)
 		if err != nil {
 			return Servers{}, err
 		}
-
-		req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
 
 		resp, err = client.doer.Do(req)
 		if err != nil {

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -1,10 +1,35 @@
 package speedtest
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
+
+var (
+	version          = "1.2.1"
+	defaultUserAgent = fmt.Sprintf("showwin/speedtest-go %s", version)
+)
 
 // Speedtest is a speedtest client.
 type Speedtest struct {
 	doer *http.Client
+}
+
+type userAgentTransport struct {
+	T         http.RoundTripper
+	UserAgent string
+}
+
+func newUserAgentTransport(T http.RoundTripper, UserAgent string) *userAgentTransport {
+	if T == nil {
+		T = http.DefaultTransport
+	}
+	return &userAgentTransport{T, UserAgent}
+}
+
+func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("User-Agent", uat.UserAgent)
+	return uat.T.RoundTrip(req)
 }
 
 // Option is a function that can be passed to New to modify the Client.
@@ -17,17 +42,31 @@ func WithDoer(doer *http.Client) Option {
 	}
 }
 
+// WithUserAgent adds the passed "User-Agent" header to all requests.
+// To use with a custom Doer, "WithDoer" must be passed before WithUserAgent:
+// `New(WithDoer(myDoer), WithUserAgent(myUserAgent))`
+func WithUserAgent(UserAgent string) Option {
+	return func(s *Speedtest) {
+		s.doer.Transport = newUserAgentTransport(s.doer.Transport, UserAgent)
+	}
+}
+
 // New creates a new speedtest client.
 func New(opts ...Option) *Speedtest {
 	s := &Speedtest{
 		doer: http.DefaultClient,
 	}
+	WithUserAgent(defaultUserAgent)(s)
 
 	for _, opt := range opts {
 		opt(s)
 	}
 
 	return s
+}
+
+func Version() string {
+	return version
 }
 
 var defaultClient = New()

--- a/speedtest/speedtest_test.go
+++ b/speedtest/speedtest_test.go
@@ -2,6 +2,7 @@ package speedtest
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -22,5 +23,41 @@ func TestNew(t *testing.T) {
 			t.Error("doer is not the same")
 		}
 	})
+}
 
+func TestUserAgent(t *testing.T) {
+	testServer := func(expectedUserAgent string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.UserAgent() == "" {
+				t.Error("Did not receive User-Agent header")
+			} else if r.UserAgent() != expectedUserAgent {
+				t.Errorf("Incorrect User-Agent header: %s, expected: %s", r.UserAgent(), expectedUserAgent)
+			}
+		}))
+	}
+
+	t.Run("DefaultUserAgent", func(t *testing.T) {
+		c := New()
+		s := testServer(defaultUserAgent)
+		c.doer.Get(s.URL)
+	})
+
+	t.Run("CustomUserAgent", func(t *testing.T) {
+		testAgent := "asdf1234"
+		s := testServer(testAgent)
+		c := New(WithUserAgent(testAgent))
+		c.doer.Get(s.URL)
+	})
+
+	// Test that With
+	t.Run("CustomUserAgentAndDoer", func(t *testing.T) {
+		testAgent := "asdf2345"
+		doer := &http.Client{}
+		s := testServer(testAgent)
+		c := New(WithDoer(doer), WithUserAgent(testAgent))
+		if c.doer != doer {
+			t.Error("doer is not the same")
+		}
+		c.doer.Get(s.URL)
+	})
 }

--- a/speedtest/user.go
+++ b/speedtest/user.go
@@ -45,8 +45,6 @@ func (client *Speedtest) FetchUserInfoContext(ctx context.Context) (*User, error
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", "Go-http-client/1.1") // Request could be rejected if not initialized
-
 	resp, err := client.doer.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR sets a custom user-agent on all requests set by the speedtest library: `showwin/speedtest-go <version>`. This UserAgent can be overridden with a new `Option`, `WithUserAgent`. This `WithUserAgent` option is just a convenience function -- it wraps the transport on the client's Doer to add a `user-agent` to all requests. As such, you can use it with a custom Doer if you want (as long as you pass the custom doer first), or you can just implement your own User-Agent on the doer you pass in.

I thought this might be a little nicer way to handle user-agents, but this PR is definitely a little opinionated, glad to adjust or close, just lmk :-) 

New Unit Tests are added to test the user-agent behavior, and all tests pass:
```
 ~/speedtest-go ❯❯❯ go test ./... -v
?       github.com/showwin/speedtest-go [no test files]
=== RUN   TestDownloadTestContext
--- PASS: TestDownloadTestContext (0.60s)
=== RUN   TestDownloadTestContextSavingMode
--- PASS: TestDownloadTestContextSavingMode (0.60s)
=== RUN   TestUploadTestContext
--- PASS: TestUploadTestContext (0.60s)
=== RUN   TestUploadTestContextSavingMode
--- PASS: TestUploadTestContextSavingMode (0.60s)
=== RUN   TestFetchServerList
--- PASS: TestFetchServerList (0.17s)
=== RUN   TestDistance
--- PASS: TestDistance (0.00s)
=== RUN   TestFindServer
--- PASS: TestFindServer (0.00s)
=== RUN   TestNew
=== RUN   TestNew/DefaultDoer
=== RUN   TestNew/CustomDoer
--- PASS: TestNew (0.00s)
    --- PASS: TestNew/DefaultDoer (0.00s)
    --- PASS: TestNew/CustomDoer (0.00s)
=== RUN   TestUserAgent
=== RUN   TestUserAgent/DefaultUserAgent
=== RUN   TestUserAgent/CustomUserAgent
=== RUN   TestUserAgent/CustomUserAgentAndDoer
--- PASS: TestUserAgent (0.00s)
    --- PASS: TestUserAgent/DefaultUserAgent (0.00s)
    --- PASS: TestUserAgent/CustomUserAgent (0.00s)
    --- PASS: TestUserAgent/CustomUserAgentAndDoer (0.00s)
=== RUN   TestFetchUserInfo
--- PASS: TestFetchUserInfo (0.05s)
PASS
ok      github.com/showwin/speedtest-go/speedtest       2.628s
```

**Note:** to access the `speedtest-go` version, I had to move it to `speedtest.go`, so if you like this behavior, new releases will need to bump the version there instead.