### PR TITLE
feature: Adding custom-url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ $ speedtest --help
 usage: speedtest-go [<flags>]
 
 Flags:
-      --help               Show context-sensitive help (also try --help-long and --help-man).
-  -l, --list               Show available speedtest.net servers.
-  -s, --server=SERVER ...  Select server id to speedtest.
-      --saving-mode        Using less memory (≒10MB), though low accuracy (especially > 30Mbps).
-      --json               Output results in json format
-      --location=LOCATION  Change the location with a precise coordinate.
-      --city=CITY          Change the location with a predefined city label.
-      --city-list          List all predefined city label.
-      --version            Show application version.
+      --help                   Show context-sensitive help (also try --help-long and --help-man).
+  -l, --list                   Show available speedtest.net servers.
+  -s, --server=SERVER ...      Select server id to run speedtest.
+      --custom-url=CUSTOM-URL  Specify the url of the server instead of getting a list from Speedtest.net
+      --saving-mode            Using less memory (≒10MB), though low accuracy (especially > 30Mbps).
+      --json                   Output results in json format
+      --location=LOCATION      Change the location with a precise coordinate. Format: lat,lon
+      --city=CITY              Change the location with a predefined city label.
+      --city-list              List all predefined city labels.
+      --version                Show application version.
 ```
 
 #### Test Internet Speed

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -12,13 +12,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type downloadWarmUpFunc func(context.Context, *http.Client, string) error
-type downloadFunc func(context.Context, *http.Client, string, int) error
-type uploadWarmUpFunc func(context.Context, *http.Client, string) error
-type uploadFunc func(context.Context, *http.Client, string, int) error
+type (
+	downloadWarmUpFunc func(context.Context, *http.Client, string) error
+	downloadFunc       func(context.Context, *http.Client, string, int) error
+	uploadWarmUpFunc   func(context.Context, *http.Client, string) error
+	uploadFunc         func(context.Context, *http.Client, string, int) error
+)
 
-var dlSizes = [...]int{350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
-var ulSizes = [...]int{100, 300, 500, 800, 1000, 1500, 2500, 3000, 3500, 4000} //kB
+var (
+	dlSizes = [...]int{350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
+	ulSizes = [...]int{100, 300, 500, 800, 1000, 1500, 2500, 3000, 3500, 4000} // kB
+)
 
 // DownloadTest executes the test to measure download speed
 func (s *Server) DownloadTest(savingMode bool) error {
@@ -116,6 +120,7 @@ func (s *Server) UploadTest(savingMode bool) error {
 func (s *Server) UploadTestContext(ctx context.Context, savingMode bool) error {
 	return s.uploadTestContext(ctx, savingMode, ulWarmUp, uploadRequest)
 }
+
 func (s *Server) uploadTestContext(
 	ctx context.Context,
 	savingMode bool,

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -46,6 +46,8 @@ type Server struct {
 	doer *http.Client
 }
 
+// CustomServer Given a URL string, return a new Server object, with as much
+// filled in as we can
 func CustomServer(s string) (*Server, error) {
 	if !strings.HasSuffix(s, "/upload.php") {
 		return nil, errors.New("please use the full URL of the server, ending in '/upload.php'")

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -8,13 +8,17 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
-const speedTestServersUrl = "https://www.speedtest.net/api/js/servers?limit=10"
-const speedTestServersAlternativeUrl = "https://www.speedtest.net/speedtest-servers-static.php"
+const (
+	speedTestServersUrl            = "https://www.speedtest.net/api/js/servers?limit=10"
+	speedTestServersAlternativeUrl = "https://www.speedtest.net/speedtest-servers-static.php"
+)
 
 type PayloadType int
 
@@ -40,6 +44,27 @@ type Server struct {
 	ULSpeed  float64       `json:"ul_speed"`
 
 	doer *http.Client
+}
+
+func CustomServer(s string) (*Server, error) {
+	if !strings.HasSuffix(s, "/upload.php") {
+		return nil, errors.New("please use the full URL of the server, ending in '/upload.php'")
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		ID:      "?",
+		Lat:     "?",
+		Lon:     "?",
+		Country: "?",
+		URL:     s,
+		Name:    u.Host,
+		Host:    u.Host,
+		Sponsor: "?",
+		doer:    http.DefaultClient,
+	}, nil
 }
 
 // ServerList list of Server

--- a/speedtest/server_test.go
+++ b/speedtest/server_test.go
@@ -99,3 +99,20 @@ func TestFindServer(t *testing.T) {
 		t.Errorf("Unexpected server ID. got: %v, expected: '1'", s[0].ID)
 	}
 }
+
+func TestCustomServer(t *testing.T) {
+	// Good server
+	got, err := CustomServer("https://example.com/upload.php")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got.Host != "example.com" {
+		t.Error("Did not properly set the Host field on a custom server")
+	}
+
+	// Missing upload.php
+	_, err = CustomServer("https://example.com")
+	if err == nil {
+		t.Error("did not fail to create a customserver without upload.php")
+	}
+}


### PR DESCRIPTION
Hoping to resolve #74 with this one! This adds a little helper function in the `speedtest` module that creates a new *Server object from a URL. Example:

```go
    s, err := speedtest.CustomServer("https://example.com/upload.php")
    checkError(err)
    ...
```

This can be used directly from the CLI app here with:

```bash
$ speedtest-go --custom-url https://example.com/upload.php
...
```

Happy to change around as needed. Thanks!