### PR TITLE
Error strings should not start with a capital letter

### DIFF
--- a/speedtest/server_test.go
+++ b/speedtest/server_test.go
@@ -66,10 +66,10 @@ func TestFindServer(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if len(s) != 1 {
-		t.Errorf("Unexpected server length. got: %v, expected: 1", len(s))
+		t.Errorf("unexpected server length. got: %v, expected: 1", len(s))
 	}
 	if s[0].ID != "1" {
-		t.Errorf("Unexpected server ID. got: %v, expected: '1'", s[0].ID)
+		t.Errorf("unexpected server ID. got: %v, expected: '1'", s[0].ID)
 	}
 
 	serverID = []int{2}
@@ -78,10 +78,10 @@ func TestFindServer(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if len(s) != 1 {
-		t.Errorf("Unexpected server length. got: %v, expected: 1", len(s))
+		t.Errorf("unexpected server length. got: %v, expected: 1", len(s))
 	}
 	if s[0].ID != "2" {
-		t.Errorf("Unexpected server ID. got: %v, expected: '2'", s[0].ID)
+		t.Errorf("unexpected server ID. got: %v, expected: '2'", s[0].ID)
 	}
 
 	serverID = []int{3, 1}
@@ -90,13 +90,13 @@ func TestFindServer(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if len(s) != 2 {
-		t.Errorf("Unexpected server length. got: %v, expected: 2", len(s))
+		t.Errorf("unexpected server length. got: %v, expected: 2", len(s))
 	}
 	if s[0].ID != "3" {
-		t.Errorf("Unexpected server ID. got: %v, expected: '3'", s[0].ID)
+		t.Errorf("unexpected server ID. got: %v, expected: '3'", s[0].ID)
 	}
 	if s[1].ID != "1" {
-		t.Errorf("Unexpected server ID. got: %v, expected: '1'", s[0].ID)
+		t.Errorf("unexpected server ID. got: %v, expected: '1'", s[0].ID)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestCustomServer(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if got.Host != "example.com" {
-		t.Error("Did not properly set the Host field on a custom server")
+		t.Error("did not properly set the Host field on a custom server")
 	}
 
 	// Missing upload.php

--- a/speedtest/speedtest_test.go
+++ b/speedtest/speedtest_test.go
@@ -29,9 +29,9 @@ func TestUserAgent(t *testing.T) {
 	testServer := func(expectedUserAgent string) *httptest.Server {
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.UserAgent() == "" {
-				t.Error("Did not receive User-Agent header")
+				t.Error("did not receive User-Agent header")
 			} else if r.UserAgent() != expectedUserAgent {
-				t.Errorf("Incorrect User-Agent header: %s, expected: %s", r.UserAgent(), expectedUserAgent)
+				t.Errorf("incorrect User-Agent header: %s, expected: %s", r.UserAgent(), expectedUserAgent)
 			}
 		}))
 	}

--- a/speedtest/user_test.go
+++ b/speedtest/user_test.go
@@ -15,10 +15,10 @@ func TestFetchUserInfo(t *testing.T) {
 	}
 	// IP
 	if len(user.IP) < 7 || len(user.IP) > 15 {
-		t.Errorf("Invalid IP length. got: %v;", user.IP)
+		t.Errorf("invalid IP length. got: %v;", user.IP)
 	}
 	if strings.Count(user.IP, ".") != 3 {
-		t.Errorf("Invalid IP format. got: %v", user.IP)
+		t.Errorf("invalid IP format. got: %v", user.IP)
 	}
 
 	// Lat
@@ -27,7 +27,7 @@ func TestFetchUserInfo(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if lat < -90 || 90 < lat {
-		t.Errorf("Invalid Latitude. got: %v, expected between -90 and 90", user.Lat)
+		t.Errorf("invalid Latitude. got: %v, expected between -90 and 90", user.Lat)
 	}
 
 	// Lon
@@ -36,11 +36,11 @@ func TestFetchUserInfo(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if lon < -180 || 180 < lon {
-		t.Errorf("Invalid Longitude. got: %v, expected between -180 and 180", user.Lon)
+		t.Errorf("invalid Longitude. got: %v, expected between -180 and 180", user.Lon)
 	}
 
 	// Isp
 	if len(user.Isp) == 0 {
-		t.Errorf("Invalid Iso. got: %v;", user.Isp)
+		t.Errorf("invalid Iso. got: %v;", user.Isp)
 	}
 }


### PR DESCRIPTION
Fix the error strings so that they start with lowercase.

ref: https://github.com/golang/go/wiki/Errors#:~:text=Error%20strings%20should%20not%20start%20with%20a%20capital%20letter%20because%20they%27ll%20often%20be%20prefixed%20before%20printing%3A