### PR TITLE
feature: proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Flags:
       --help               Show context-sensitive help (also try --help-long and --help-man).
   -l, --list               Show available speedtest.net servers.
   -s, --server=SERVER ...  Select server id to speedtest.
+      --custom-url=CUSTOM-URL Specify the url of the server instead of getting a list from Speedtest.net
       --saving-mode        Using less memory (≒10MB), though low accuracy (especially > 30Mbps).
       --json               Output results in json format
       --location=LOCATION  Change the location with a precise coordinate.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Flags:
       --location=LOCATION  Change the location with a precise coordinate.
       --city=CITY          Change the location with a predefined city label.
       --city-list          List all predefined city label.
+      --proxy              Set a proxy(http(s) or socks) for the speedtest.
       --version            Show application version.
 ```
 
@@ -142,12 +143,17 @@ import (
 )
 
 func main() {
-	user, _ := speedtest.FetchUserInfo()
+	var speedtestClient = speedtest.New()
+	
+	// Use a proxy for the speedtest. eg: socks://127.0.0.1:7890
+	// speedtest.WithProxy("socks://127.0.0.1:7890")(speedtestClient)
+	
+	user, _ := speedtestClient.FetchUserInfo()
 	// Get a list of servers near a specified location
 	// user.SetLocationByCity("Tokyo")
 	// user.SetLocation("Osaka", 34.6952, 135.5006)
 
-	serverList, _ := speedtest.FetchServers(user)
+	serverList, _ := speedtestClient.FetchServers(user)
 	targets, _ := serverList.FindServer([]int{})
 
 	for _, s := range targets {

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -2,7 +2,9 @@ package speedtest
 
 import (
 	"fmt"
+	"log"
 	"net/http"
+	"net/url"
 )
 
 var (
@@ -45,9 +47,23 @@ func WithDoer(doer *http.Client) Option {
 // WithUserAgent adds the passed "User-Agent" header to all requests.
 // To use with a custom Doer, "WithDoer" must be passed before WithUserAgent:
 // `New(WithDoer(myDoer), WithUserAgent(myUserAgent))`
-func WithUserAgent(UserAgent string) Option {
+func WithUserAgent(userAgent string) Option {
 	return func(s *Speedtest) {
-		s.doer.Transport = newUserAgentTransport(s.doer.Transport, UserAgent)
+		s.doer.Transport = newUserAgentTransport(s.doer.Transport, userAgent)
+	}
+}
+
+// WithProxy provides an easy way to set a proxy(http(s) or socks) for requests.
+func WithProxy(host string) Option {
+	return func(s *Speedtest) {
+		parse, err := url.Parse(host)
+		if err != nil {
+			log.Printf("Skip: can not parse the proxy: %s\n, please check.", parse.String())
+			return
+		}
+		s.doer.Transport = &http.Transport{Proxy: func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(host)
+		}}
 	}
 }
 


### PR DESCRIPTION
this patch add a proxy support for speedtest and all request traffic will pass through agent.

Usage:  
1. `./speedtest -s xxxx --proxy=socks://127.0.0.1:7890`
2. ~~`speedtest.WithProxy("http://127.0.0.1:7890")(speedtestClient)`~~`speedtest.WithUserConfig(&speedtest.UserConfig{Proxy: "http://127.0.0.1:7890"})(speedtestClient)` with code.