### PR TITLE
fix: hide redundant json content

### DIFF
--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -53,7 +53,7 @@ type Server struct {
 	ULSpeed      float64       `json:"ul_speed"`
 	TestDuration TestDuration  `json:"test_duration"`
 
-	Context *Speedtest
+	Context *Speedtest `json:"-"`
 }
 
 type TestDuration struct {


### PR DESCRIPTION
Remove Context field output in json.