### PR TITLE
fix: clean-up the rate sequence goroutines to avoid leaking

### DIFF
--- a/speedtest/data_manager.go
+++ b/speedtest/data_manager.go
@@ -225,18 +225,26 @@ func (dm *DataManager) rateCapture() *time.Ticker {
 	oldTotalDownload := dm.totalDownload
 	oldTotalUpload := dm.totalUpload
 	go func() {
-		for range ticker.C {
-			newTotalDownload := dm.totalDownload
-			newTotalUpload := dm.totalUpload
-			deltaDownload := newTotalDownload - oldTotalDownload
-			deltaUpload := newTotalUpload - oldTotalUpload
-			oldTotalDownload = newTotalDownload
-			oldTotalUpload = newTotalUpload
-			if deltaDownload != 0 {
-				dm.DownloadRateSequence = append(dm.DownloadRateSequence, deltaDownload)
-			}
-			if deltaUpload != 0 {
-				dm.UploadRateSequence = append(dm.UploadRateSequence, deltaUpload)
+	loop:
+		for {
+			select {
+			case <-ticker.C:
+				newTotalDownload := dm.totalDownload
+				newTotalUpload := dm.totalUpload
+				deltaDownload := newTotalDownload - oldTotalDownload
+				deltaUpload := newTotalUpload - oldTotalUpload
+				oldTotalDownload = newTotalDownload
+				oldTotalUpload = newTotalUpload
+				if deltaDownload != 0 {
+					dm.DownloadRateSequence = append(dm.DownloadRateSequence, deltaDownload)
+				}
+				if deltaUpload != 0 {
+					dm.UploadRateSequence = append(dm.UploadRateSequence, deltaUpload)
+				}
+			default:
+				if !dm.running {
+					break loop
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
As stated on Ticker.Stop:

    Stop does not close the channel, to prevent a concurrent goroutine
    reading from the channel from seeing an erroneous "tick".

This sole fact prevents the goroutine from exiting, and in result, causes a leak that is especially problematic when the project is used through an API and not a CLI.

This particular bug is directly affecting the Telegraf's [Internet Speed Input Plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/internet_speed/internet_speed.go), so this fix is only resolving the part relevant to the plugin. 

There are two more occurrences of this pattern:
https://github.com/showwin/speedtest-go/blob/320b5b755b5ecf42797de0910defe1fa064634ec/speedtest/data_manager.go#L103 https://github.com/showwin/speedtest-go/blob/320b5b755b5ecf42797de0910defe1fa064634ec/speedtest/data_manager.go#L114

Unfortunately, fixing them would probably require an API change, so I'm purposefully leaving that to the maintainers of this project.