### PR TITLE
fix: specify servers with FetchServerByID()

### DIFF
--- a/speedtest.go
+++ b/speedtest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/showwin/speedtest-go/speedtest"
@@ -78,6 +79,17 @@ func main() {
 			task.CheckError(err)
 			targets = []*speedtest.Server{target}
 			task.Println("Skip: Using Custom Server")
+		} else if len(*serverIds) > 0 {
+			// TODO: need async fetch to speedup
+			for _, id := range *serverIds {
+				serverPtr, errFetch := speedtestClient.FetchServerByID(strconv.Itoa(id))
+				if errFetch != nil {
+					continue // Silently Skip all ids that actually don't exist.
+				}
+				targets = append(targets, serverPtr)
+			}
+			task.CheckError(err)
+			task.Printf("Found %d Specified Public Servers", len(targets))
 		} else {
 			servers, err = speedtestClient.FetchServers()
 			task.CheckError(err)

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -344,6 +344,7 @@ func (servers Servers) FindServer(serverID []int) (Servers, error) {
 			id, _ := strconv.Atoi(s.ID)
 			if sid == id {
 				retServer = append(retServer, s)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Related to #126 
Use the `FetchServerByID(id string)` to find a specific server.