### PR TITLE
fix: cursor hidden after listing available servers

### DIFF
--- a/speedtest.go
+++ b/speedtest.go
@@ -99,7 +99,7 @@ func main() {
 				task.Complete()
 				task.manager.Reset()
 				showServerList(servers)
-				os.Exit(1)
+				os.Exit(0)
 			}
 			targets, err = servers.FindServer(*serverIds)
 			task.CheckError(err)


### PR DESCRIPTION
Related to #171 