### PR TITLE
Expose a property to set Dialer.Control

### DIFF
--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -41,6 +42,7 @@ type UserConfig struct {
 	Proxy         string
 	Source        string
 	DnsBindSource bool
+	DialerControl func(network, address string, c syscall.RawConn) error
 	Debug         bool
 	PingMode      Proto
 
@@ -143,12 +145,14 @@ func (s *Speedtest) NewUserConfig(uc *UserConfig) {
 		LocalAddr: tcpSource,
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
+		Control:   uc.DialerControl,
 	}
 
 	s.ipDialer = &net.Dialer{
 		LocalAddr: icmpSource,
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
+		Control:   uc.DialerControl,
 	}
 
 	s.config.T = &http.Transport{


### PR DESCRIPTION
The PR introduces a DialerControl property to allow a caller to execute syscalls on the socket before a connection is established.

Binding an IP via `Source` property is not always an option, in my case I am using a series of devices which get all the same IP and all have the same subnet: the only way to control which one has to be used is to bind the socket to a specific interface.

Here an example of the code
```
interfaceName := "XYZ"
speedTestClient = speedtest.New(speedtest.WithUserConfig(&speedtest.UserConfig{
	DialerControl: func(network, address string, conn syscall.RawConn) error {
		var operr error
		if err = conn.Control(func(fd uintptr) {
			operr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, interfaceName)
		}); err != nil {
			return err
		}

		if operr != nil {
			return operr
		}

		return nil
	},
}))
```

This allows speedtest-go to work directly on the interface without having to bind on a specific IP.

The PR doesn't change the dialer used for the resolver as the library alters the DefaultResolver.

NOTE: SO_BINDTODEVICE is Linux specific, not sure what the other OS support, but the PR has no impact on the portability of the library itself as it only allows to define the `Control` property of the Dialer