### PR TITLE
Ensure that the context cancel and deadline hit are respected and the related errors properly propagated

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -305,7 +305,7 @@ func (s *Server) HTTPPing(
 	}
 
 	if contextErr != nil {
-		return nil, contextErr
+		return latencies, contextErr
 	}
 
 	if failTimes == echoTimes {

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -268,6 +268,7 @@ func (s *Server) HTTPPing(
 	echoFreq time.Duration,
 	callback func(latency time.Duration),
 ) (latencies []int64, err error) {
+	var contextErr error
 	u, err := url.Parse(s.URL)
 	if err != nil || len(u.Host) == 0 {
 		return nil, err
@@ -285,6 +286,11 @@ func (s *Server) HTTPPing(
 		resp, err := s.Context.doer.Do(req)
 		endTime := time.Since(sTime)
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				contextErr = err
+				break
+			}
+
 			failTimes++
 			continue
 		}
@@ -297,9 +303,15 @@ func (s *Server) HTTPPing(
 		}
 		time.Sleep(echoFreq)
 	}
+
+	if contextErr != nil {
+		return nil, contextErr
+	}
+
 	if failTimes == echoTimes {
 		return nil, ErrConnectTimeout
 	}
+
 	return
 }
 


### PR DESCRIPTION
This PR improves the behaviour of how the context is handled in HTTPPing.

Currently, if a context is cancelled, the HTTPPing will keep trying executing the requests, failing them, to return at the end a timeout error, therefore misreporting the reason for which the requests are actually failing.
On top of this, if a number of pings passed before the context got cancelled or the deadline was hit, the error will not be reported at all, making it hard for the caller to understand if the operation was succesful or not.

In my specific case I need to ensure that if I don't get a response within 30/60 seconds the speedtest terminates and reports the reason for the termination and in case it's a timeout it doesn't report general errors.

The PR ensure that if a context cancelled or a deadline hit, the code ping terminates and returns whatever latencies it collected, also returning the appropriate error.

This PR is only for HTTPPing but TCPPing has the same issue, not sure if it applies to ICMPPing but it might be the same there.