### PR TITLE
fix(api): unified packet loss interface

### DIFF
--- a/example/packet_loss/main.go
+++ b/example/packet_loss/main.go
@@ -52,7 +52,9 @@ func main() {
 	// use mixed PacketLoss
 	mixed, err := analyzer.RunMulti(serverList.Hosts())
 	checkError(err)
-	fmt.Printf("Mixed packets lossed: %.2f\n", mixed)
+	fmt.Printf("Mixed packets lossed: %.2f%%\n", mixed.LossPercent())
+	fmt.Printf("Mixed packets lossed: %.2f\n", mixed.Loss())
+	fmt.Printf("Mixed packets lossed: %s\n", mixed)
 }
 
 func checkError(err error) {

--- a/speedtest/transport/tcp.go
+++ b/speedtest/transport/tcp.go
@@ -197,6 +197,13 @@ func (p PLoss) Loss() float64 {
 	return 1 - (float64(p.Sent-p.Dup))/float64(p.Max+1)
 }
 
+func (p PLoss) LossPercent() float64 {
+	if p.Sent == 0 {
+		return -1
+	}
+	return p.Loss() * 100
+}
+
 func (client *Client) PacketLoss() (*PLoss, error) {
 	err := client.Write(packetLoss)
 	if err != nil {


### PR DESCRIPTION
breaking change: 
from `func (pla *PacketLossAnalyzer) RunMulti(hosts []string) (float64, error) {`
to `func (pla *PacketLossAnalyzer) RunMulti(hosts []string) (*transport.PLoss, error) {`

from `func (pla *PacketLossAnalyzer) RunMultiWithContext(ctx context.Context, hosts []string) (float64, error) {`
to `func (pla *PacketLossAnalyzer) RunMultiWithContext(ctx context.Context, hosts []string) (*transport.PLoss, error) {`