### PR TITLE
fix: json output not using speed format

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -61,6 +61,7 @@ func (s *Server) MultiDownloadTestContext(ctx context.Context, servers Servers) 
 	if s.DLSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.DLSpeed = -1 // N/A
 	}
+	s.DLSpeedStr = s.DLSpeed.String()
 	return nil
 }
 
@@ -96,6 +97,7 @@ func (s *Server) MultiUploadTestContext(ctx context.Context, servers Servers) er
 	if s.ULSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.ULSpeed = -1 // N/A
 	}
+	s.ULSpeedStr = s.ULSpeed.String()
 	return nil
 }
 
@@ -125,6 +127,7 @@ func (s *Server) downloadTestContext(ctx context.Context, downloadRequest downlo
 	if s.DLSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.DLSpeed = -1 // N/A
 	}
+	s.DLSpeedStr = s.DLSpeed.String()
 	s.TestDuration.Download = &duration
 	s.testDurationTotalCount()
 	return nil
@@ -156,6 +159,7 @@ func (s *Server) uploadTestContext(ctx context.Context, uploadRequest uploadFunc
 	if s.ULSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.ULSpeed = -1 // N/A
 	}
+	s.ULSpeedStr = s.ULSpeed.String()
 	s.TestDuration.Upload = &duration
 	s.testDurationTotalCount()
 	return nil

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -49,8 +49,10 @@ type Server struct {
 	MaxLatency   time.Duration   `json:"max_latency"`
 	MinLatency   time.Duration   `json:"min_latency"`
 	Jitter       time.Duration   `json:"jitter"`
-	DLSpeed      ByteRate        `json:"dl_speed"`
-	ULSpeed      ByteRate        `json:"ul_speed"`
+	DLSpeed      ByteRate        `json:"-"`
+	ULSpeed      ByteRate        `json:"-"`
+	DLSpeedStr   string          `json:"dl_speed"`
+	ULSpeedStr   string          `json:"ul_speed"`
 	TestDuration TestDuration    `json:"test_duration"`
 	PacketLoss   transport.PLoss `json:"packet_loss"`
 

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	naString         = "N/A"
+	zeroSpeedString  = "0.00 Mbps"
 	version          = "1.7.7"
 	DefaultUserAgent = fmt.Sprintf("showwin/speedtest-go %s", version)
 )

--- a/speedtest/unit.go
+++ b/speedtest/unit.go
@@ -47,15 +47,15 @@ var globalByteRateUnit UnitType
 
 func (r ByteRate) String() string {
 	if r == 0 {
-		return "0.00 Mbps"
+		return zeroSpeedString
 	}
 	if r == -1 {
-		return "N/A"
+		return naString
 	}
 	if globalByteRateUnit != UnitTypeDefaultMbps {
 		return r.Byte(globalByteRateUnit)
 	}
-	return strconv.FormatFloat(float64(r/125000.0), 'f', 2, 64) + " Mbps"
+	return strconv.FormatFloat(r.Mbps(), 'f', 2, 64) + " " + DecimalBitsUnits[2]
 }
 
 // SetUnit Set global output units
@@ -74,10 +74,10 @@ func (r ByteRate) Gbps() float64 {
 // Byte Specifies the format output byte rate
 func (r ByteRate) Byte(formatType UnitType) string {
 	if r == 0 {
-		return "0.00 Mbps"
+		return zeroSpeedString
 	}
 	if r == -1 {
-		return "N/A"
+		return naString
 	}
 	return format(float64(r), formatType)
 }


### PR DESCRIPTION
Closes #219 

~Implemented [Marshaler](https://pkg.go.dev/encoding/json#Marshaler) for `ByteRate`,~ Added extra DL/UL fields to `Server` so that the json output uses the specified format and scaling for the speed values.


Example output (string) (for default format/unit):

```json
...
"dl_speed": "341.80 Mbps",
"ul_speed": "298.76 Mbps",
...
```

Example output (string) (for binary-bytes unit option):

```json
...
"dl_speed": "40.79 MiB/s",
"ul_speed": "31.11 MiB/s",
...
```

Before output (float) (always the raw float value):

```json
...
"dl_speed": 42814913.17295695,
"ul_speed": 37902142.46883963,
...
```