### PR TITLE
Fix Packet Loss Sample Code Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,14 @@ import (
 	"fmt"
 	"github.com/showwin/speedtest-go/speedtest"
 	"github.com/showwin/speedtest-go/speedtest/transport"
+	"log"
 )
+
+func checkError(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
 
 // Note: The current packet loss analyzer does not support udp over http.
 // This means we cannot get packet loss through a proxy.


### PR DESCRIPTION
In the original sample code ```checkError``` is not defined.