### PR TITLE
chore: bump workflows/release/go/version from 1.19.0 to 1.23.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23.4
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
#233 