### PR TITLE
Add a Dockerfile to allow running from a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apk add --no-cache git
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN GOOS=$(echo $TARGETPLATFORM | cut -d/ -f1) \
+    GOARCH=$(echo $TARGETPLATFORM | cut -d/ -f2) \
+    go build -o speedtest-go
+
+# Final stage
+FROM alpine:latest
+
+# Install bash
+RUN apk add --no-cache bash
+
+# Create non-root user
+RUN adduser -D -h /home/speedtest speedtest
+
+WORKDIR /home/speedtest
+
+# Copy the binary from builder
+COPY --from=builder /app/speedtest-go /usr/local/bin/
+
+# Switch to non-root user
+USER speedtest
+
+# Set default shell
+SHELL ["/bin/bash", "-c"]
+
+# Set the entrypoint to bash, we do this rather than using the speedtest command directly
+# such that you can also use this container in an interactive way to run speedtests.
+# see the README for more info and examples.
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,85 @@ $ nix-shell -p speedtest-go
 Please download the compatible package from [Releases](https://github.com/showwin/speedtest-go/releases).
 If there are no compatible packages you want, please let me know on [Issue Tracker](https://github.com/showwin/speedtest-go/issues).
 
+#### Docker Build
+
+To build a multi-architecture Docker image:
+
+```bash
+# Check if you already have a builder instance
+docker buildx ls
+
+# Only create a new builder if you don't have one
+# If the above command shows no builders or none are in use, run:
+docker buildx create --name mybuilder --use
+
+# Build and push for multiple platforms
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t yourusername/speedtest-go:latest --push .
+```
+
+#### Running the Container
+
+##### Docker
+Run the container with default settings (interactive shell):
+```bash
+docker run -it yourusername/speedtest-go:latest
+```
+
+Run a speedtest with specific arguments:
+```bash
+# Run a basic speedtest
+docker run yourusername/speedtest-go:latest speedtest-go
+
+# Run with specific server
+docker run yourusername/speedtest-go:latest speedtest-go --server 6691
+
+# Run with multiple servers and JSON output
+docker run yourusername/speedtest-go:latest speedtest-go --server 6691 --server 6087 --json
+
+# Run with custom location
+docker run yourusername/speedtest-go:latest speedtest-go --location=60,-110
+```
+
+##### Kubernetes
+Here's an example Kubernetes pod specification that runs a speedtest:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: speedtest
+spec:
+  containers:
+  - name: speedtest
+    image: yourusername/speedtest-go:latest
+    # Base command to run bash
+    command: ["speedtest-go"]
+    # Or run with specific arguments
+    # args: ["--server", "6691", "--json"]
+  restartPolicy: Never
+```
+
+For a more complete deployment, you might want to use a CronJob to run periodic speedtests:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: speedtest
+spec:
+  schedule: "0 */6 * * *"  # Run every 6 hours
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: speedtest
+            image: yourusername/speedtest-go:latest
+            command: ["speedtest-go"]
+            args: ["--json"]
+          restartPolicy: OnFailure
+```
+
 ### Usage
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/showwin/speedtest-go
 
-go 1.19
+go 1.24.2
 
 require (
 	github.com/chelnak/ysmrr v0.5.0


### PR DESCRIPTION
I took the approach here of making the Dockerfile "interactive", if you run it in an interactive way you can manually run the speedtest command, this can be happy if you are trying to troubleshoot something from within a containerized environment.

I also included examples of how you would run the Dockerfile in a non-interactive way if you just want to run the command without installing it on your machine.

Lastly a included a few Kubernetes examples of how you might deploy this to run it from a Kubernetes environment

I also updated Go.