### PR TITLE
Add jsonl output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flags:
       --custom-url=CUSTOM-URL  Specify the url of the server instead of fetching from speedtest.net.
       --saving-mode            Test with few resources, though low accuracy (especially > 30Mbps).
       --json                   Output results in json format.
+      --jsonl                  Output results in jsonl format (one json object per line).
       --unix                   Output results in unix like format.
       --location=LOCATION      Change the location with a precise coordinate (format: lat,lon).
       --city=CITY              Change the location with a predefined city label.

--- a/speedtest/output.go
+++ b/speedtest/output.go
@@ -12,6 +12,12 @@ type fullOutput struct {
 	Servers   Servers    `json:"servers"`
 }
 
+type singleServerOutput struct {
+	Timestamp outputTime `json:"timestamp"`
+	UserInfo  *User      `json:"user_info"`
+	Server    *Server    `json:"server"`
+}
+
 type outputTime time.Time
 
 func (t outputTime) MarshalJSON() ([]byte, error) {
@@ -25,6 +31,17 @@ func (s *Speedtest) JSON(servers Servers) ([]byte, error) {
 			Timestamp: outputTime(time.Now()),
 			UserInfo:  s.User,
 			Servers:   servers,
+		},
+	)
+}
+
+// JSONL outputs a single server result in JSON format
+func (s *Speedtest) JSONL(server *Server) ([]byte, error) {
+	return json.Marshal(
+		singleServerOutput{
+			Timestamp: outputTime(time.Now()),
+			UserInfo:  s.User,
+			Server:    server,
 		},
 	)
 }


### PR DESCRIPTION
The database I want to store the output in doesn't like arrays in json output very much so I added jsonl support which will output each server under test on a separate line as separate json objects.