### PR TITLE
chore: bump actions/toolkit/cache from v2.1.0 to v4.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: check out
         uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
related to #254 