### PR TITLE
source: accept interface names on Linux (`SO_BINDTODEVICE`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Flags:
       --source=SOURCE          Bind a source interface for the speedtest.
       --dns-bind-source        DNS request binding source (experimental).
                                eg: --source=10.20.0.101
+                               eg: --source=eth0  (Linux only)
   -m  --multi                  Enable multi-server mode.
   -t  --thread=THREAD          Set the number of concurrent connections.
       --search=SEARCH          Fuzzy search servers by a keyword.
@@ -260,6 +261,8 @@ func main() {
 	
 	// Select a network card as the data interface.
 	// speedtest.WithUserConfig(&speedtest.UserConfig{Source: "192.168.1.101"})(speedtestClient)
+	// On Linux, a network interface name also works (binds via SO_BINDTODEVICE):
+	// speedtest.WithUserConfig(&speedtest.UserConfig{Source: "eth0"})(speedtestClient)
 	
 	// Get user's network information
 	// user, _ := speedtestClient.FetchUserInfo()

--- a/speedtest/source_linux.go
+++ b/speedtest/source_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package speedtest
+
+import (
+	"net"
+	"syscall"
+)
+
+// resolveInterface checks if source is a network interface name.
+// If so, it returns the interface's first IPv4 address and a
+// DialerControl function that binds sockets to the interface
+// via SO_BINDTODEVICE.
+func resolveInterface(source string) (ip net.IP, control func(string, string, syscall.RawConn) error, ok bool) {
+	iface, err := net.InterfaceByName(source)
+	if err != nil {
+		return nil, nil, false
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, nil, false
+	}
+	for _, a := range addrs {
+		ipnet, isIPNet := a.(*net.IPNet)
+		if isIPNet && ipnet.IP.To4() != nil {
+			devName := iface.Name
+			ctrl := func(_, _ string, c syscall.RawConn) error {
+				var serr error
+				c.Control(func(fd uintptr) {
+					serr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, devName)
+				})
+				return serr
+			}
+			return ipnet.IP, ctrl, true
+		}
+	}
+	return nil, nil, false
+}

--- a/speedtest/source_other.go
+++ b/speedtest/source_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package speedtest
+
+import (
+	"net"
+	"syscall"
+)
+
+func resolveInterface(_ string) (net.IP, func(string, string, syscall.RawConn) error, bool) {
+	return nil, nil, false
+}

--- a/speedtest/source_test.go
+++ b/speedtest/source_test.go
@@ -1,0 +1,39 @@
+package speedtest
+
+import (
+	"net"
+	"runtime"
+	"testing"
+)
+
+func TestResolveInterface(t *testing.T) {
+	t.Run("InvalidName", func(t *testing.T) {
+		_, _, ok := resolveInterface("nonexistent0")
+		if ok {
+			t.Error("expected ok=false for nonexistent interface")
+		}
+	})
+
+	t.Run("IPAddress", func(t *testing.T) {
+		_, _, ok := resolveInterface("127.0.0.1")
+		if ok {
+			t.Error("expected ok=false for IP address")
+		}
+	})
+
+	t.Run("Loopback", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("SO_BINDTODEVICE requires Linux")
+		}
+		ip, ctrl, ok := resolveInterface("lo")
+		if !ok {
+			t.Fatal("expected ok=true for lo")
+		}
+		if !ip.Equal(net.IPv4(127, 0, 0, 1)) {
+			t.Errorf("expected 127.0.0.1, got %s", ip)
+		}
+		if ctrl == nil {
+			t.Error("expected non-nil control function")
+		}
+	})
+}

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -98,6 +98,15 @@ func (s *Speedtest) NewUserConfig(uc *UserConfig) {
 	}
 	if len(uc.Source) > 0 {
 		_, address := parseAddr(uc.Source)
+
+		// Try as interface name first (Linux: SO_BINDTODEVICE)
+		if ifIP, ctrl, ok := resolveInterface(address); ok {
+			address = ifIP.String()
+			if uc.DialerControl == nil {
+				uc.DialerControl = ctrl
+			}
+		}
+
 		addr0, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("[%s]:0", address)) // dynamic tcp port
 		if err == nil {
 			tcpSource = addr0


### PR DESCRIPTION
When `--source` is given an interface name instead of an IP address, resolve the first IPv4 address and bind all sockets to the device via `SO_BINDTODEVICE`. This ensures all connections — including the initial API calls to `speedtest.net` — are routed through the specified interface, which is required on multi-homed hosts where source IP binding alone does not control route selection.