### PR TITLE
fix: resolve upload redirects before streaming

### DIFF
--- a/speedtest/data_manager_test.go
+++ b/speedtest/data_manager_test.go
@@ -118,6 +118,50 @@ func TestUploadRequestCountsOnlyConfirmedUploads(t *testing.T) {
 	}
 }
 
+func TestResolveUploadURLFollowsTemporaryRedirect(t *testing.T) {
+	var received int64
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("request method is %s, want POST", r.Method)
+		}
+		var err error
+		received, err = io.Copy(io.Discard, r.Body)
+		if err != nil {
+			t.Errorf("failed to read redirected upload: %v", err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer targetServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirectServer.Close()
+
+	client := New()
+	target := &Server{URL: redirectServer.URL, Context: client}
+	target.resolveUploadURL(context.Background())
+	if target.URL != targetServer.URL {
+		t.Fatalf("resolved upload URL is %q, want %q", target.URL, targetServer.URL)
+	}
+	if err := uploadRequest(context.Background(), target, 0); err != nil {
+		t.Fatalf("upload request failed: %v", err)
+	}
+
+	want := int64(ulSizes[0]*100-51) * 10
+	if received != want {
+		t.Fatalf("resolved endpoint received %d bytes, want %d", received, want)
+	}
+	if got := client.GetTotalUpload(); got != want {
+		t.Fatalf("counted %d upload bytes, want %d", got, want)
+	}
+}
+
 func TestUploadRequestDoesNotCountRejectedUploads(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -81,6 +81,7 @@ func (s *Server) MultiUploadTestContext(ctx context.Context, servers Servers) er
 		if server.ID == s.ID {
 			mainIDIndex = i
 		}
+		server.resolveUploadURL(ctx)
 		sp := server
 		dbg.Printf("Register Upload Handler: %s\n", sp.URL)
 		td = server.Context.RegisterUploadHandler(func() {
@@ -134,12 +135,36 @@ func (s *Server) downloadTestContext(ctx context.Context, downloadRequest downlo
 
 // UploadTest executes the test to measure upload speed
 func (s *Server) UploadTest() error {
-	return s.uploadTestContext(context.Background(), s.uploadRequest())
+	return s.UploadTestContext(context.Background())
 }
 
 // UploadTestContext executes the test to measure upload speed, observing the given context.
 func (s *Server) UploadTestContext(ctx context.Context) error {
+	s.resolveUploadURL(ctx)
 	return s.uploadTestContext(ctx, s.uploadRequest())
+}
+
+func (s *Server) resolveUploadURL(ctx context.Context) {
+	if s.Context.config.TestMode == TCPTest {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, s.URL, nil)
+	if err != nil {
+		return
+	}
+	resp, err := s.Context.doer.Do(req)
+	if err != nil {
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.Request == nil || resp.Request.URL == nil {
+		return
+	}
+	resolvedURL := resp.Request.URL.String()
+	if resolvedURL != s.URL {
+		dbg.Printf("Resolved upload URL: %s -> %s\n", s.URL, resolvedURL)
+		s.URL = resolvedURL
+	}
 }
 
 func (s *Server) downloadRequest() downloadFunc {


### PR DESCRIPTION
Bell Ottawa server 54836 advertises an HTTP upload URL that redirects to an HTTPS Ookla host. The server closes the connection while the request body is still streaming, so the Go client gets `broken pipe` before it can receive and follow the 307. The result is `Upload: N/A` with 0 bytes confirmed.

This resolves the upload URL once with a HEAD request before starting the upload workers. The payload is then sent directly to the final endpoint, and TCP tests are unchanged.

I tested with:

```text
speedtest-go --server 54836 --thread 16 --no-download
Before: Upload: N/A (Used: 0.00MB Confirmed: 0.0%)
After:  Upload: 1026.86 Mbps (Used: 1310.33MB Confirmed: 98.9%)
```

Also passed:

```text
go test ./...
go vet ./...
go test -race ./speedtest -run "TestResolveUploadURLFollowsTemporaryRedirect|TestUploadRequest"
```