### PR TITLE
fix: reject HTTP errors during ping

### DIFF
--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -447,6 +447,11 @@ func (s *Server) HTTPPing(
 			failTimes++
 			continue
 		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			_ = resp.Body.Close()
+			failTimes++
+			continue
+		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		if i > 0 {

--- a/speedtest/request_test.go
+++ b/speedtest/request_test.go
@@ -2,10 +2,52 @@ package speedtest
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"testing"
 	"time"
 )
+
+func TestHTTPPingRejectsHTTPErrorAfterRedirect(t *testing.T) {
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer targetServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirectServer.Close()
+
+	client := New()
+	target := &Server{URL: redirectServer.URL + "/speedtest/upload.php", Context: client}
+	latencies, err := target.HTTPPing(context.Background(), 1, 0, nil)
+	if !errors.Is(err, ErrConnectTimeout) {
+		t.Fatalf("HTTPPing error is %v, want %v", err, ErrConnectTimeout)
+	}
+	if len(latencies) != 0 {
+		t.Fatalf("HTTPPing returned %d latencies for HTTP 500, want 0", len(latencies))
+	}
+}
+
+func TestHTTPPingAcceptsSuccessfulResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New()
+	target := &Server{URL: server.URL + "/speedtest/upload.php", Context: client}
+	latencies, err := target.HTTPPing(context.Background(), 1, 0, nil)
+	if err != nil {
+		t.Fatalf("HTTPPing failed: %v", err)
+	}
+	if len(latencies) != 1 {
+		t.Fatalf("HTTPPing returned %d latencies, want 1", len(latencies))
+	}
+}
 
 func TestDownloadTestContext(t *testing.T) {
 	idealSpeed := 0.1 * 8 * float64(runtime.NumCPU()) * 10 / 0.1 // one mockRequest per second with all CPU cores


### PR DESCRIPTION
`HTTPPing` currently treats every received HTTP response as a successful latency sample, including 500 responses. That keeps unhealthy servers eligible for selection and allows an explicitly selected server to continue toward the bandwidth tests.

This counts non-2xx responses as failed ping attempts after redirects are followed. If every attempt fails, the existing `ErrConnectTimeout` path marks the server unavailable.

I found two nearby examples where every resolved resource returns 500:

```text
[16610] Clarkson University
[ 1300] WTC Communications
```

Before this change, both showed measured latency in `--list`. Afterward, both show `Timeout`, while the other 18 nearby servers remain available. Explicitly selecting server 16610 now exits during latency validation without starting an upload.

Passed:

```text
go test ./...
go vet ./...
go test -race ./speedtest -run TestHTTPPing
```