### PR TITLE
fix: report final rates from measured bytes

### DIFF
--- a/speedtest/data_manager.go
+++ b/speedtest/data_manager.go
@@ -107,6 +107,7 @@ type TestDirection struct {
 	maxWorkers      int32                       // configured upload worker limit
 	RateSequence    []int64                     // rate history sequence
 	welford         *internal.Welford           // std/EWMA/mean
+	finalRateValue  float64                     // measured bytes per second at test termination
 	captureCallback func(realTimeRate ByteRate) // user callback
 	closeFunc       func()                      // close func
 	*funcGroup                                  // actually exec function
@@ -242,8 +243,7 @@ func (td *TestDirection) Start(cancel context.CancelFunc, mainRequestHandlerInde
 	once := sync.Once{}
 	td.closeFunc = func() {
 		once.Do(func() {
-			stopCapture <- true
-			close(stopCapture)
+			stopCapture()
 			td.manager.runningRW.Lock()
 			td.manager.running = false
 			td.manager.runningRW.Unlock()
@@ -378,14 +378,16 @@ func reducedUploadWorkerCount(active int32, rate, bestRate float64, backlog int6
 	return target
 }
 
-func (td *TestDirection) rateCapture() chan bool {
+func (td *TestDirection) rateCapture() func() {
 	ticker := time.NewTicker(td.manager.rateCaptureFrequency)
 	var prevTotalDataVolume int64 = 0
-	stopCapture := make(chan bool)
+	stopCapture := make(chan struct{})
+	captureStopped := make(chan struct{})
 	td.welford = internal.NewWelford(5*time.Second, td.manager.rateCaptureFrequency)
 	sTime := time.Now()
 	go func(t *time.Ticker) {
 		defer t.Stop()
+		defer close(captureStopped)
 		for {
 			select {
 			case <-t.C:
@@ -410,14 +412,29 @@ func (td *TestDirection) rateCapture() chan bool {
 				if td.captureCallback != nil {
 					td.captureCallback(ByteRate(td.welford.EWMA()))
 				}
-			case stop := <-stopCapture:
-				if stop {
-					return
-				}
+			case <-stopCapture:
+				td.captureFinalRate(sTime, time.Now())
+				return
 			}
 		}
 	}(ticker)
-	return stopCapture
+	return func() {
+		close(stopCapture)
+		<-captureStopped
+	}
+}
+
+func (td *TestDirection) captureFinalRate(start, end time.Time) {
+	elapsed := end.Sub(start)
+	if elapsed <= 0 {
+		td.finalRateValue = 0
+		return
+	}
+	td.finalRateValue = float64(td.GetTotalDataVolume()) / elapsed.Seconds()
+}
+
+func (td *TestDirection) finalRate() float64 {
+	return td.finalRateValue
 }
 
 func (dm *DataManager) NewChunk() Chunk {

--- a/speedtest/data_manager_test.go
+++ b/speedtest/data_manager_test.go
@@ -55,6 +55,55 @@ func TestDataManager_GetAvgDownloadRate(t *testing.T) {
 	}
 }
 
+func TestDataManager_FinalRateUsesCapturedBytesAndDuration(t *testing.T) {
+	dm := NewDataManager()
+	dm.download.AddTotalDataVolume(3_000_000)
+	start := time.Unix(0, 0)
+	dm.download.captureFinalRate(start, start.Add(2*time.Second))
+
+	const want = 1_500_000.0
+	got := dm.download.finalRate()
+	if got != want {
+		t.Fatalf("final download rate is %v bytes/s, want %v", got, want)
+	}
+}
+
+func TestDataManager_FinalRateStopsBeforeCancellation(t *testing.T) {
+	const (
+		captureTime = 20 * time.Millisecond
+		beforeStop  = int64(1_000)
+		afterStop   = int64(1_000_000)
+	)
+	dm := NewDataManager()
+	dm.SetNThread(1)
+	dm.SetCaptureTime(captureTime)
+	dm.SetRateCaptureFrequency(time.Millisecond)
+
+	var once sync.Once
+	var direction *TestDirection
+	direction = dm.RegisterDownloadHandler(func() {
+		once.Do(func() {
+			direction.AddTotalDataVolume(beforeStop)
+		})
+		time.Sleep(time.Millisecond)
+	})
+	direction.Start(func() {
+		direction.AddTotalDataVolume(afterStop)
+	}, 0)
+
+	if got := direction.GetTotalDataVolume(); got != beforeStop+afterStop {
+		t.Fatalf("total bytes are %d, want %d", got, beforeStop+afterStop)
+	}
+	got := direction.finalRate()
+	if got <= 0 {
+		t.Fatalf("final rate is %v, want a positive value", got)
+	}
+	maxBeforeStopRate := float64(beforeStop) / captureTime.Seconds()
+	if got > maxBeforeStopRate*1.1 {
+		t.Fatalf("final rate is %v bytes/s, which includes bytes added after the stop boundary", got)
+	}
+}
+
 func TestDataManager_GetUploadConfirmationRatio(t *testing.T) {
 	dm := NewDataManager()
 	dm.upload.AddTotalReadVolume(2 * 1000 * 1000)

--- a/speedtest/request.go
+++ b/speedtest/request.go
@@ -59,7 +59,7 @@ func (s *Server) MultiDownloadTestContext(ctx context.Context, servers Servers) 
 		return ErrorUninitializedManager
 	}
 	td.Start(cancel, mainIDIndex) // block here
-	s.DLSpeed = ByteRate(td.manager.GetEWMADownloadRate())
+	s.DLSpeed = ByteRate(td.finalRate())
 	if s.DLSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.DLSpeed = -1 // N/A
 	}
@@ -95,7 +95,7 @@ func (s *Server) MultiUploadTestContext(ctx context.Context, servers Servers) er
 		return ErrorUninitializedManager
 	}
 	td.Start(cancel, mainIDIndex) // block here
-	s.ULSpeed = ByteRate(td.manager.GetEWMAUploadRate())
+	s.ULSpeed = ByteRate(td.finalRate())
 	if s.ULSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.ULSpeed = -1 // N/A
 	}
@@ -117,14 +117,15 @@ func (s *Server) downloadTestContext(ctx context.Context, downloadRequest downlo
 	var requestTimes int64 = 0
 	start := time.Now()
 	_context, cancel := context.WithCancel(ctx)
-	s.Context.RegisterDownloadHandler(func() {
+	td := s.Context.RegisterDownloadHandler(func() {
 		atomic.AddInt64(&requestTimes, 1)
 		if err := downloadRequest(_context, s, 3); err != nil {
 			atomic.AddInt64(&errorTimes, 1)
 		}
-	}).Start(cancel, 0)
+	})
+	td.Start(cancel, 0)
 	duration := time.Since(start)
-	s.DLSpeed = ByteRate(s.Context.GetEWMADownloadRate())
+	s.DLSpeed = ByteRate(td.finalRate())
 	if s.DLSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.DLSpeed = -1 // N/A
 	}
@@ -186,14 +187,15 @@ func (s *Server) uploadTestContext(ctx context.Context, uploadRequest uploadFunc
 	var requestTimes int64 = 0
 	start := time.Now()
 	_context, cancel := context.WithCancel(ctx)
-	s.Context.RegisterUploadHandler(func() {
+	td := s.Context.RegisterUploadHandler(func() {
 		atomic.AddInt64(&requestTimes, 1)
 		if err := uploadRequest(_context, s, 4); err != nil {
 			atomic.AddInt64(&errorTimes, 1)
 		}
-	}).Start(cancel, 0)
+	})
+	td.Start(cancel, 0)
 	duration := time.Since(start)
-	s.ULSpeed = ByteRate(s.Context.GetEWMAUploadRate())
+	s.ULSpeed = ByteRate(td.finalRate())
 	if s.ULSpeed == 0 && float64(errorTimes)/float64(requestTimes) > 0.1 {
 		s.ULSpeed = -1 // N/A
 	}

--- a/speedtest/request_test.go
+++ b/speedtest/request_test.go
@@ -76,14 +76,14 @@ func TestDownloadTestContext(t *testing.T) {
 	idealSpeed := 0.1 * 8 * float64(runtime.NumCPU()) * 10 / 0.1 // one mockRequest per second with all CPU cores
 	delta := 0.15
 	latency, _ := time.ParseDuration("5ms")
+	client := New()
 	server := Server{
 		URL:     "https://dummy.com/upload.php",
 		Latency: latency,
-		Context: defaultClient,
+		Context: client,
 	}
 
-	server.Context.Reset()
-	server.Context.SetRateCaptureFrequency(time.Millisecond)
+	server.Context.SetRateCaptureFrequency(50 * time.Millisecond)
 	server.Context.SetCaptureTime(time.Second)
 
 	err := server.downloadTestContext(
@@ -92,6 +92,9 @@ func TestDownloadTestContext(t *testing.T) {
 	)
 	if err != nil {
 		t.Error(err)
+	}
+	if value := float64(server.DLSpeed) * 8 / 1000 / 1000; value < idealSpeed*(1-delta) || idealSpeed*(1+delta) < value {
+		t.Errorf("got unexpected final download rate '%v', expected between %v and %v", value, idealSpeed*(1-delta), idealSpeed*(1+delta))
 	}
 	value := server.Context.GetAvgDownloadRate()
 	if value < idealSpeed*(1-delta) || idealSpeed*(1+delta) < value {
@@ -107,14 +110,14 @@ func TestUploadTestContext(t *testing.T) {
 	delta := 0.15                        // tolerance scope (-0.05, +0.05)
 
 	latency, _ := time.ParseDuration("5ms")
+	client := New()
 	server := Server{
 		URL:     "https://dummy.com/upload.php",
 		Latency: latency,
-		Context: defaultClient,
+		Context: client,
 	}
 
-	server.Context.Reset()
-	server.Context.SetRateCaptureFrequency(time.Millisecond)
+	server.Context.SetRateCaptureFrequency(50 * time.Millisecond)
 	server.Context.SetCaptureTime(time.Second)
 	server.Context.SetNThread(1)
 
@@ -124,6 +127,9 @@ func TestUploadTestContext(t *testing.T) {
 	)
 	if err != nil {
 		t.Error(err)
+	}
+	if value := float64(server.ULSpeed) * 8 / 1000 / 1000; value < idealSpeed*(1-delta) || idealSpeed*(1+delta) < value {
+		t.Errorf("got unexpected final upload rate '%v', expected between %v and %v", value, idealSpeed*(1-delta), idealSpeed*(1+delta))
 	}
 	value := server.Context.GetAvgUploadRate()
 	if value < idealSpeed*(1-delta) || idealSpeed*(1+delta) < value {


### PR DESCRIPTION
`DLSpeed` and `ULSpeed` currently use the same five-second EWMA/Welford estimator as the live callbacks. The estimator has a strong low bias while it converges from zero. Short tests can end before that bias disappears, causing the final result to be low as well.

The deterministic regression injects one megabyte every 100 ms for one second and accepts a 15% timing tolerance around the injected rate. It makes no network requests.

| Direction | Injected rate | Current `master` result | Deviation |
|---|---:|---:|---:|
| Download | 2,560 Mbps | 1,773 Mbps | 30.7% low |
| Upload | 80 Mbps | 59.75 Mbps | 25.3% low |

Current `master` fails both assertions. The download target scales with the number of test workers.

Recorded live traces show the same low bias in the current estimator. Across six traces per direction, 92.9% of download samples and 99.1% of upload samples after the first second were below the cumulative measured-byte rate.

The current estimator also produced these short-run upload averages:

| Requested duration | Final upload result | Confirmed-byte average | NIC average |
|---|---:|---:|---:|
| 5 seconds | 917.49 Mbps | 1,050.61 Mbps | 1,111.05 Mbps |
| 10 seconds | 1,048.02 Mbps | 1,064.98 Mbps | 1,121.10 Mbps |

Under current `master`, increasing the requested duration from five to ten seconds raised the final reported upload rate by 14.23%. Over the same runs, confirmed-byte throughput rose 1.37% and NIC throughput rose 0.90%.

This change snapshots measured bytes and elapsed time when rate capture stops, before in-flight requests are cancelled. Final download and upload results use that snapshot:

- Download uses received bytes.
- Upload uses confirmed bytes.
- Single-server and multi-server paths use the same calculation.
- Welford stopping behavior is unchanged.
- Live callbacks remain unchanged and retain the existing warm-up bias.

With this change, ten runs averaged 2,558.46 Mbps for `Server.DLSpeed`, 0.06% below the injected download rate, and 79.94 Mbps for `Server.ULSpeed`, 0.07% below the injected upload rate. A fixed-input test verifies that 3 MB over two seconds produces exactly 1.5 MB/s. A shutdown-boundary test adds 1,000 bytes before the stop and 1,000,000 bytes during cancellation, then verifies that the cancellation bytes are excluded.

Passed:

```text
go test ./... -skip '^TestDynamicRate$'
go vet ./...
go test -race ./speedtest -skip '^TestDynamicRate$'
```

`TestDynamicRate` is the pre-existing test that contacts an external server. The cutoff tests also passed 100 repetitions.
