### PR TITLE
Add trust command for Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inspired by [sivel/speedtest-cli](https://github.com/sivel/speedtest-cli)
 
 ```bash
 $ brew tap showwin/speedtest
+$ brew trust --formula showwin/speedtest/speedtest
 $ brew install speedtest
 
 ### How to Update ###


### PR DESCRIPTION
Small update to the README, Hombrew now requires explicit trusting of 3rd party Taps or Formula